### PR TITLE
DEV-1625: Add missing env variables in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,6 @@ MATRIX_PREFIX_DM=false
 MATRIX_RICH_TEXT=true
 DATA_PATH=./storage
 
-
+API_URL=https://api.globalid.dev
 # Mixpanel
 MIXPANEL_PROJECT_TOKEN=


### PR DESCRIPTION
This pull request includes a small change to the `.env.example` file. The change introduces a new environment variable `API_URL` with the value `https://api.globalid.dev`.